### PR TITLE
feat: add rfc 7807 error implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@types/rollup-plugin-peer-deps-external": "^2.2.5",
     "eslint": "^9.27.0",
     "globals": "^16.2.0",
+    "http-status-codes": "^2.3.0",
     "husky": "^9.1.7",
     "jest": "^29.7.0",
     "rollup": "^4.41.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       globals:
         specifier: ^16.2.0
         version: 16.2.0
+      http-status-codes:
+        specifier: ^2.3.0
+        version: 2.3.0
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -1690,6 +1693,9 @@ packages:
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
+
+  http-status-codes@2.3.0:
+    resolution: {integrity: sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -4995,6 +5001,8 @@ snapshots:
       debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
+
+  http-status-codes@2.3.0: {}
 
   https-proxy-agent@7.0.6:
     dependencies:

--- a/src/http/error/RFC7807Problem.test.ts
+++ b/src/http/error/RFC7807Problem.test.ts
@@ -1,0 +1,66 @@
+import {RFC7807Problem} from "./RFC7807Problem";
+import {StatusCodes} from "http-status-codes";
+
+describe("RFC7807Problem", () => {
+    it("should serialize to JSON correctly", () => {
+        const exampleError = new RFC7807Problem({
+            status: StatusCodes.FORBIDDEN,
+            title: "Forbidden",
+            detail: "You do not have permission to access this resource.",
+            message: "User tried to access resource without permission"
+        });
+
+        expect(exampleError).toBeInstanceOf(RFC7807Problem);
+        expect(exampleError).toBeInstanceOf(Error);
+
+        const serializedError = JSON.stringify(exampleError);
+        const deserializedError = JSON.parse(serializedError);
+
+        // Ensure message property is not present
+        expect(deserializedError).toStrictEqual({
+            status: 403,
+            title: "Forbidden",
+            detail: "You do not have permission to access this resource.",
+            type: "about:blank"
+        })
+    });
+
+    it("should serialize subclass properties", () => {
+        // An example implementation of an error based on the RFC 7807 problem
+        class CustomError extends RFC7807Problem {
+            public readonly customProperty: string | undefined;
+
+            constructor(customProperty?: string) {
+                super({title: "Custom Error", type: "CUSTOM_ERROR"});
+
+                this.customProperty = customProperty;
+            }
+        }
+
+        const myCustomError = new CustomError("This information is useful");
+        const serializedError = JSON.stringify(myCustomError);
+        const deserializedError = JSON.parse(serializedError);
+
+        expect("customProperty" in deserializedError).toBe(true);
+        expect(deserializedError).toStrictEqual({
+            title: "Custom Error",
+            type: "CUSTOM_ERROR",
+            customProperty: "This information is useful"
+        });
+    });
+
+    it("should follow: message > detail > title > type for Error.message", () => {
+        const e1 = new RFC7807Problem({ type: "X" });
+        expect(e1.message).toBe("X");
+
+        const e2 = new RFC7807Problem({ title: "T", type: "X" });
+        expect(e2.message).toBe("T");
+
+        const e3 = new RFC7807Problem({ detail: "D", title: "T", type: "X" });
+        expect(e3.message).toBe("D");
+
+        const e4 = new RFC7807Problem({ message: "M", detail: "D", title: "T", type: "X" });
+        expect(e4.message).toBe("M");
+    });
+});
+

--- a/src/http/error/RFC7807Problem.ts
+++ b/src/http/error/RFC7807Problem.ts
@@ -1,0 +1,70 @@
+import {StatusCodes} from "http-status-codes";
+
+export interface RFC7807Options {
+    /**
+     * @default "about:blank"
+     */
+    type?: string;
+    title?: string;
+    status?: StatusCodes;
+    detail?: string;
+    instance?: string;
+    // Explicit override for Error.message
+    message?: string;
+}
+
+/**
+ * Represents an <b>RFC 7807 Problem</b> Details error.
+ * @see https://datatracker.ietf.org/doc/html/rfc7807
+ */
+export class RFC7807Problem extends Error {
+    public readonly type: string | undefined;
+    public readonly title: string | undefined;
+    public readonly status: StatusCodes | undefined;
+    public readonly detail: string | undefined;
+    public readonly instance: string | undefined;
+
+    public constructor({title, instance, type = "about:blank", status, detail, message}: RFC7807Options) {
+        const errorMessage = message ?? detail ?? title ?? type;
+        super(errorMessage);
+
+        this.name = "RFC7807Problem";
+        this.title = title;
+        this.instance = instance;
+        this.type = type;
+        this.status = status;
+        this.detail = detail;
+
+        Object.setPrototypeOf(this, RFC7807Problem.prototype);
+
+        // Better stack traces in V8
+        if (typeof Error.captureStackTrace === "function") {
+            Error.captureStackTrace(this, this.constructor);
+        }
+    }
+
+    public toJSON(): Record<string, unknown> {
+        const serializedProperties: Record<string, unknown> = {};
+
+        for (const key in this) {
+            if (Object.prototype.hasOwnProperty.call(this, key)) {
+                const value = this[key];
+
+                // These are internal properties we don't want to serialize/expose
+                if (key === 'message' || key === 'name' || key === 'stack') {
+                    continue;
+                }
+
+                if (value !== undefined) {
+                    serializedProperties[key] = value;
+                }
+            }
+        }
+
+        return serializedProperties;
+    }
+}
+
+export function isRFC7807Problem(value: unknown): value is RFC7807Problem {
+    return value instanceof RFC7807Problem;
+}

--- a/src/http/error/index.ts
+++ b/src/http/error/index.ts
@@ -1,0 +1,1 @@
+export * from "./RFC7807Problem";

--- a/src/http/index.ts
+++ b/src/http/index.ts
@@ -1,0 +1,1 @@
+export * from "./error";

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export * from "./lodash";
 export * from "./monad";
 export * from "./zod";
 export * from "./request";
+export * from "./http";


### PR DESCRIPTION
This pull request introduces a new error class for representing RFC 7807 Problem Details and integrates it into the codebase. The changes include adding the `http-status-codes` dependency, implementing the `RFC7807Problem` class, providing comprehensive tests, and updating exports to make the new error class available throughout the project.

**Error Handling Improvements:**

* Added a new `RFC7807Problem` class in `src/http/error/RFC7807Problem.ts` that implements the RFC 7807 Problem Details standard for HTTP APIs, including serialization and message prioritization logic.
* Added unit tests for `RFC7807Problem` in `src/http/error/RFC7807Problem.test.ts`, covering serialization, subclassing, and message selection behavior.
* Exported `RFC7807Problem` from `src/http/error/index.ts`, `src/http/index.ts`, and updated the root `src/index.ts` to make the error class available across the codebase. [[1]](diffhunk://#diff-523e8b9570fc7b52f5e3a1f0726b3d80bab11c5850fc66dbca6c4fa8d0a4f0e5R1) [[2]](diffhunk://#diff-697ecb1c31942111c5abbfbd44e1d67c2ac847518d6afe2b1a8d05d2e7c5df14R1) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R5)

**Dependency Management:**

* Added `http-status-codes@^2.3.0` to `package.json` and updated `pnpm-lock.yaml` to include the new dependency and its snapshot. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R46) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR63-R65) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1697-R1699) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5005-R5006)